### PR TITLE
Drawer opaque overlay issue

### DIFF
--- a/src/components/item/itemBase.tsx
+++ b/src/components/item/itemBase.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { IItem } from '@/interfaces/models';
+import type { IItem } from '@/interfaces/models';
 import { ItemViewState } from '@/components/item/itemViewState';
 import { ItemEditState } from '@/components/item/itemEditState';
 import { useHomeContext } from '@/context/homeContext';
@@ -9,20 +9,25 @@ import { Drawer, DrawerTrigger, DrawerContent } from '@/components/ui/drawer';
 import { noise } from '@/utils';
 
 export const Item = ({ item }: { item: IItem }) => {
-  const { drawerOpen, handleDrawerOpenChange, handleSelectedItemChange, isEditing, handleEditingChange } =
+  const { drawerOpen, handleDrawerOpenChange, handleSelectedItemChange, isEditing, handleEditingChange, selectedItem } =
     useHomeContext();
+
   const { title, author, thumbnail, placeholderCover } = item;
+  const isThisItemSelected = selectedItem?._id === item._id;
+  const isThisDrawerOpen = isThisItemSelected && drawerOpen;
 
   return (
     <Drawer
-      open={drawerOpen}
+      open={isThisDrawerOpen}
       onOpenChange={(open) => {
         handleDrawerOpenChange(open);
         if (open) {
           handleSelectedItemChange(item);
           handleEditingChange(false);
         } else {
-          handleSelectedItemChange(null);
+          if (isThisItemSelected) {
+            handleSelectedItemChange(null);
+          }
         }
       }}
     >
@@ -31,7 +36,7 @@ export const Item = ({ item }: { item: IItem }) => {
           <div className="w-full h-24">
             {thumbnail ? (
               <Image
-                src={thumbnail}
+                src={thumbnail || '/placeholder.svg'}
                 alt={title}
                 width={400}
                 height={300}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -33,7 +33,7 @@ const DrawerOverlay = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/40', className)} {...props} />
+  <DrawerPrimitive.Overlay ref={ref} className={cn('fixed inset-0 z-50 bg-black/80', className)} {...props} />
 ));
 DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 


### PR DESCRIPTION
- In a folder with multiple items, if you opened the drawer for one item, it would open the drawers for all the items
- This created stacked overlays, with the final effect being a black, opaque overlay underneath the drawer
- Added a simple check to see if an item associated with a drawer is the one that's currently selected
- If it is, only then open the item's drawer
- Fixes #31 