### PR TITLE
Keep icons always visible on mobile

### DIFF
--- a/src/components/sidebar/favoriteStar.tsx
+++ b/src/components/sidebar/favoriteStar.tsx
@@ -12,7 +12,7 @@ export function FavoriteStar({ isFavorite, onClick }: FavoriteStarProps) {
       className={
         isFavorite
           ? 'fill-yellow-400 stroke-yellow-400 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer p-1 transition-colors duration-50 fade-in-50 fade-out-50'
-          : 'opacity-0 group-hover/fav:opacity-100 transition-colors duration-50 fade-in-50 fade-out-50 fill-neutral-300 stroke-neutral-300 dark:fill-neutral-600 dark:stroke-neutral-600 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer p-1 duration-50'
+          : 'md:opacity-0 group-hover/fav:opacity-100 transition-colors duration-50 fade-in-50 fade-out-50 fill-neutral-300 stroke-neutral-300 dark:fill-neutral-600 dark:stroke-neutral-600 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer p-1 duration-50'
       }
       onClick={onClick}
     />

--- a/src/components/sidebar/settingsIcon.tsx
+++ b/src/components/sidebar/settingsIcon.tsx
@@ -9,9 +9,9 @@ export const SettingsIcon = forwardRef(function SettingsIcon(
     <span
       {...props}
       ref={ref}
-      className="opacity-0 group-hover/fav:opacity-100 transition-colors duration-50 fade-in-50 fade-out-50 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer"
+      className="md:opacity-0 group-hover/fav:opacity-100 transition-colors duration-50 fade-in-50 fade-out-50 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer"
     >
-      <Bolt className="opacity-0 group-hover/fav:opacity-100 transition-colors duration-50 fade-in-50 fade-out-50 stroke-neutral-300 dark:stroke-neutral-600 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer p-[3px] duration-50" />
+      <Bolt className="md:opacity-0 group-hover/fav:opacity-100 transition-colors duration-50 fade-in-50 fade-out-50 stroke-neutral-300 dark:stroke-neutral-600 hover:bg-neutral-200 dark:hover:bg-neutral-900 aspect-square rounded-md cursor-pointer p-[3px] duration-50" />
     </span>
   );
 });

--- a/src/components/sidebar/sidebarHeader.tsx
+++ b/src/components/sidebar/sidebarHeader.tsx
@@ -17,7 +17,7 @@ export function AppSidebarHeader() {
                   <span className="font-semibold">Folders</span>
                 </div>
               </div>
-              <div className="opacity-0 group-hover/item:opacity-100 transition-opacity duration-50 fade-in-50 fade-out-50">
+              <div className="md:opacity-0 group-hover/item:opacity-100 transition-opacity duration-50 fade-in-50 fade-out-50">
                 <AddFolderDialog />
               </div>
             </div>


### PR DESCRIPTION
- Because of the over animations, the sidebar buttons (add folder, settings) would be invisible on touch screens
- Ensure hover animations only happen on desktop (`window.innerWidth > 768`)
- Closes #40 