### PR TITLE
Map users to their Google identity using their Google ID

### DIFF
--- a/src/actions/user/createNewUser.ts
+++ b/src/actions/user/createNewUser.ts
@@ -27,6 +27,7 @@ export async function createNewUser(user: GoogleUser): Promise<boolean> {
     if (!configsCollectionExists) await createNewCollection('configs');
 
     const newUser: IUser = await new User({
+      id: user.id,
       name: user.name,
       email: user.email,
       username: user.email.split('@')[0]

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -13,7 +13,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   callbacks: {
     async signIn({ user }: { user: GoogleUser }) {
       await mongo();
-      const existingUser = await User.findOne({ email: user.email });
+      const existingUser = await User.findOne({ id: user.id });
       if (!existingUser) {
         return await createNewUser(user);
       }

--- a/src/interfaces/models/user.interface.ts
+++ b/src/interfaces/models/user.interface.ts
@@ -2,6 +2,7 @@ import { Document, Types} from 'mongoose';
 
 export interface IUser extends Document {
   _id: Types.ObjectId;
+  id: string;
   name: string;
   email: string;
   username: string;

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,13 +1,14 @@
-import mongoose from "mongoose";
-import { IUser } from "../interfaces/models/user.interface";
+import mongoose from 'mongoose';
+import { IUser } from '../interfaces/models/user.interface';
 
 const userSchema = new mongoose.Schema<IUser>({
+  id: { type: String, required: true, unique: true },
   name: { type: String, required: true },
-  email: { type: String, required: true, unique: true }, // email is automatically indexed
+  email: { type: String, required: true, unique: true },
   username: { type: String, required: true, unique: true },
-  created_at: { type: Date, default: Date.now },
+  created_at: { type: Date, default: Date.now }
 });
 
-const User = mongoose.models.User || mongoose.model<IUser>("User", userSchema);
+const User = mongoose.models.User || mongoose.model<IUser>('User', userSchema);
 
 export default User;


### PR DESCRIPTION
Previously, email was being used to identify users. This PR modifies the User interface and the authentication logic to change that.